### PR TITLE
Fixes/share document feature fixes

### DIFF
--- a/tutify/src/components/TutorProfile/DocList.js
+++ b/tutify/src/components/TutorProfile/DocList.js
@@ -53,6 +53,21 @@ export class DocList extends React.Component {
       .catch(err => console.log(err));
   }
 
+
+
+  presentableName(name){
+    return  name.substring(0, name.lastIndexOf("."));
+  }
+
+  presentableExtension(name){
+    return name.substring(name.lastIndexOf(".") + 1);
+  }
+
+  presentableUploadTime(time){
+    var date = time.substring(0,9);
+    var hour = time.substring(11,16);
+    return date+" at "+hour;
+  }
   // tutor deletes a documents from files list
   getSelectedFiletoDelete(event, encrypted_file_name) {
     swal({
@@ -133,9 +148,10 @@ export class DocList extends React.Component {
                         <TableHead>
                           <TableRow>
                             <TableCell>Name</TableCell>
-                            <TableCell>Creation Date</TableCell>
-                            <TableCell>Share to Specific Course</TableCell>
-                            <TableCell>Share to Specific Student</TableCell>
+                            <TableCell>Extension</TableCell>
+                            <TableCell>Uploaded on</TableCell>
+                            <TableCell>Share to <br/>Specific Course</TableCell>
+                            <TableCell>Share to <br/>Specific Student</TableCell>
                             <TableCell>Download</TableCell>
                             <TableCell>Select File(s) to Delete</TableCell>
                           </TableRow>


### PR DESCRIPTION
This combines all the fixes of #138. This includes:
 - Functional checkboxes for file sharing to specific students
 - Allowing Many students to be selected in order to send documents individually to many students.
 - Deleting the weird " /:file" extension on the My Students URL 
 - Displaying file informations on the My Documents page such as the file extension, the time it was uploaded at (in a readable format) and the actual tutor name instead of its id.
- Querying the classes in the "Share to classes" page by something unique instead of the first and last name. In this pull request, the account object id is used for the query instead.
