### PR TITLE
Fix tutor login redirecting to dashboard page

### DIFF
--- a/tutify/src/components/Login.js
+++ b/tutify/src/components/Login.js
@@ -58,16 +58,12 @@ export class Login extends React.Component {
 
           console.log("Session created")
 
-          // Check if user was redirected to login page from another page
-          if(!this.props.location.state) {
-            if (res.userInfo.__t === 'student') {
-              window.location = "dashboard";
-            }
-            else if (res.userInfo.__t === 'tutor') {
-              window.location = "profile";
-            }
-          } else {
-            window.location = this.props.location.state.from.pathname;
+          // Redirect to welcome page
+          if (res.userInfo.__t === 'student') {
+            window.location = "dashboard";
+          }
+          else if (res.userInfo.__t === 'tutor') {
+            window.location = "profile";
           }
         }
         else {


### PR DESCRIPTION
The issue was because I was trying to redirect the user to the page they came from if they tried to access a page without login in, but it seems like the browser or something remembers the last page you were on so if you were logged in as a student a you were on dashboard, the tutor was redirected to dashboard. I removed since it wasn't necessary anyway.

Issue #191 